### PR TITLE
Fixing rounding issue in safari

### DIFF
--- a/src/jquery.qrcode.js
+++ b/src/jquery.qrcode.js
@@ -253,7 +253,7 @@
 		drawModules = function (qr, context, settings) {
 
 			var moduleCount = qr.moduleCount,
-				moduleSize = settings.size / moduleCount,
+				moduleSize = Math.round(settings.size / moduleCount),
 				fn = drawModuleDefault,
 				row, col;
 


### PR DESCRIPTION
without this, safari shows weird rounding issues when drawing the arcs on the canvas.
